### PR TITLE
fix wrp-c wrp_struct_to error behavior when invalid msg type given

### DIFF
--- a/src/wrp-c.c
+++ b/src/wrp-c.c
@@ -334,7 +334,7 @@ void wrp_free_struct( wrp_msg_t *msg )
 
 static ssize_t __wrp_struct_to_bytes( const wrp_msg_t *msg, char **bytes )
 {
-    ssize_t rv;
+    ssize_t rv = -1;
     const struct wrp_req_msg *req = & ( msg->u.req );
     const struct wrp_event_msg *event = & ( msg->u.event );
     const struct wrp_svc_registration_msg *reg = & ( msg->u.reg );
@@ -345,6 +345,7 @@ static ssize_t __wrp_struct_to_bytes( const wrp_msg_t *msg, char **bytes )
         return -1;
     }
 
+    *bytes = NULL;
     struct req_res_t *encode = malloc( sizeof( struct req_res_t ) );
 
     memset( encode, 0, sizeof( struct req_res_t ) );

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -652,11 +652,15 @@ void test_all()
     }
 
     printf( "Testing NULL msg handling\n" );
-    size = wrp_struct_to( NULL, WRP_BYTES, bytes );
+    size = wrp_struct_to( NULL, WRP_BYTES, &bytes );
     CU_ASSERT( size < 0 );
-    printf( "Testing Invalid type handling\n" );
-    size = wrp_struct_to( &test[2].in, 911, bytes );
+    printf( "Testing Invalid conversion type handling\n" );
+    size = wrp_struct_to( &test[2].in, 911, &bytes );
     CU_ASSERT( size < 0 );
+    printf( "Testing Invalid message type handling\n" );
+    size = wrp_struct_to( (wrp_msg_t*) "*** Invalid WRP message\n", WRP_BYTES, &bytes );
+    CU_ASSERT( size < 0 );
+    CU_ASSERT(NULL == bytes);
     printf( "Testing NULL data handling\n" );
     size = wrp_struct_to( &test[2].in, WRP_BYTES, NULL );
     CU_ASSERT( size < 0 );


### PR DESCRIPTION
Fix function wrp_struct_to error behavior when an invalid msg type is given.
It's returning an uninitialized value, but should be -1.
This is fixed.