### PR TITLE
Use the int64_t formatter name to allow strict format checking to wor…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,8 @@ set(SOURCES wrp-c.c)
 add_library(${PROJ_WRPC} STATIC ${HEADERS} ${SOURCES})
 add_library(${PROJ_WRPC}.shared SHARED ${HEADERS} ${SOURCES})
 set_target_properties(${PROJ_WRPC}.shared PROPERTIES OUTPUT_NAME ${PROJ_WRPC})
+set_property(TARGET ${PROJ_WRPC} PROPERTY C_STANDARD 99)
+set_property(TARGET ${PROJ_WRPC}.shared PROPERTY C_STANDARD 99)
 
 install (TARGETS ${PROJ_WRPC} DESTINATION lib${LIB_SUFFIX})
 install (TARGETS ${PROJ_WRPC}.shared DESTINATION lib${LIB_SUFFIX})

--- a/src/wrp-c.c
+++ b/src/wrp-c.c
@@ -1217,8 +1217,8 @@ static void decodeMapRequest( msgpack_object deserialized, struct req_res_t **de
 
             switch( ValueType.type ) {
                 case MSGPACK_OBJECT_POSITIVE_INTEGER: {
-                    printf( "Map value is int %ld\n", ValueType.via.i64 );
-                    sprintf( mapdecodeReq->metadata->data_items[v].value, "%ld", ValueType.via.i64 );
+                    printf( "Map value is int %" PRId64 "\n", ValueType.via.i64 );
+                    sprintf( mapdecodeReq->metadata->data_items[v].value, "%" PRId64, ValueType.via.i64 );
                     v++;
                 }
                 break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W  -g -fprofile-arcs -ftest-cove
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -O0")
 
 add_executable(simple simple.c ../src/wrp-c.c ../src/wrp-c.c)
+set_property(TARGET simple PROPERTY C_STANDARD 99)
 
 target_link_libraries (simple -lmsgpackc -ltrower-base64)
 target_link_libraries (simple gcov)


### PR DESCRIPTION
…k everywhere.