### PR TITLE
replacing strncpy by memcpy due to gcc8

### DIFF
--- a/src/wrp-c.c
+++ b/src/wrp-c.c
@@ -716,7 +716,7 @@ static ssize_t __wrp_keep_alive_to_string (char **bytes )
         data = ( char* ) malloc( sizeof( char ) * ( length + 1 ) );   /* +1 for '\0' */
 
         if( NULL != data ) {
-            strncpy( data, keep_alive_fmt, length );
+            memcpy( data, keep_alive_fmt, length );
             data[length] = '\0';
             *bytes = data;
         } else {


### PR DESCRIPTION
gcc 8 higher versions uses -Wstringop-truncation flag
which check the truncation of terminating NUL char from
the source string.
strncpy is replaced with memcpy to avoid error instead
of going to -Wno-stringop-truncation

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>